### PR TITLE
Custom file extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 A PHPStorm Plugin providing custom PHP class templates.
 
 * PHP Exception Class (With selection which Exception Class to extend)
-* PHP Class From Template (New file from `File Templates` with defined file extension `class.php`
+* PHP Class From Template (New file from `File Templates` with defined file extension `class.*` (e.g. `class.php`)
 
 ## Install
 
@@ -15,7 +15,7 @@ Install the plugin by going to `Settings -> Plugins -> Browse repositories` and 
 
 ## Usage
 
-**PHP Class From Template** uses File Templates from `Settings -> Editor -> File and Code Templates -> Files` templates with file extension `class.php`
+**PHP Class From Template** uses File Templates from `Settings -> Editor -> File and Code Templates -> Files` templates with file extension `class.*`
 
 **PHP Exception Class** uses File Template `PHP Exception`
 

--- a/resources/META-INF/plugin.xml
+++ b/resources/META-INF/plugin.xml
@@ -8,12 +8,12 @@
       Provides additional file templates for php development<br>
       <ul>
         <li>PHP Exception Class (With selection which Exception Class to extend)</li>
-        <li>PHP Class From Template (New file from <b>File Templates</b> with defined file extension <b>class.php</b></li>
+        <li>PHP Class From Template (New file from <b>File Templates</b> with defined file extension <b>class.*</b> (e.g. class.php)</li>
       </ul>
 
       <h3>PHP Class From Template Usage</h3>
 
-      <p>PHP Class From Template uses File Templates with file extension "class.php"</p>
+      <p>PHP Class From Template uses File Templates with file extension "class.*"</p>
     ]]>
   </description>
 

--- a/src/com/aurimasniekis/phpclasstemplates/actions/NewPHPExceptionClass.java
+++ b/src/com/aurimasniekis/phpclasstemplates/actions/NewPHPExceptionClass.java
@@ -5,7 +5,6 @@ import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDirectory;
 import com.intellij.psi.PsiFile;
 import com.jetbrains.php.actions.PhpNewBaseAction;
-import com.jetbrains.php.actions.PhpNewClassDialog;
 import com.jetbrains.php.templates.PhpCreateFileFromTemplateDataProvider;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;

--- a/src/com/aurimasniekis/phpclasstemplates/actions/NewPHPTemplateClass.java
+++ b/src/com/aurimasniekis/phpclasstemplates/actions/NewPHPTemplateClass.java
@@ -1,6 +1,5 @@
 package com.aurimasniekis.phpclasstemplates.actions;
 
-import com.aurimasniekis.phpclasstemplates.dialog.PhpNewExceptionClassDialog;
 import com.aurimasniekis.phpclasstemplates.dialog.PhpNewTemplateClassDialog;
 import com.intellij.openapi.project.Project;
 import com.intellij.psi.PsiDirectory;


### PR DESCRIPTION
Hi, I really like this plugin, but I needed support for templates with other extensions than `php`, just like in standard File Templates. So here is PR for such a functionality.

There are many instances when this might come in handy, in my case I wanted to define a test case template for nette/tester that by convention uses `phpt` extension.

What this PR does:
- You can define File Template with extension `class.*`.
- When you select a template in PHP Class From Template dialog, the selected file extension is automatically changed based on the extension of the selected File Template, e.g. `class.php` -> `php`, `class.phpt` -> `phpt`.
- The change of file extension in PHP Class From Template dialog does not interfere with standard PHP Class dialog.